### PR TITLE
Fix ResponseBody connection leak

### DIFF
--- a/src/main/java/com/here/oksse/RealServerSentEvent.java
+++ b/src/main/java/com/here/oksse/RealServerSentEvent.java
@@ -31,7 +31,6 @@ class RealServerSentEvent implements ServerSentEvent {
     private OkHttpClient client;
     private Call call;
     private Reader sseReader;
-    private ResponseBody responseBody;
 
     private long reconnectTime = TimeUnit.SECONDS.toMillis(3);
     private long readTimeoutMillis = 0;
@@ -82,8 +81,7 @@ class RealServerSentEvent implements ServerSentEvent {
     }
 
     private void openSse(Response response) {
-        responseBody = response.body();
-        sseReader = new Reader(responseBody.source());
+        sseReader = new Reader(response.body().source());
         sseReader.setTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS);
         listener.onOpen(this, response);
 
@@ -139,8 +137,8 @@ class RealServerSentEvent implements ServerSentEvent {
         if (call != null) {
             call.cancel();
         }
-        if (responseBody != null) {
-            responseBody.close();
+        if (reader != null) {
+            reader.close();
         }
     }
 

--- a/src/main/java/com/here/oksse/RealServerSentEvent.java
+++ b/src/main/java/com/here/oksse/RealServerSentEvent.java
@@ -137,8 +137,8 @@ class RealServerSentEvent implements ServerSentEvent {
         if (call != null) {
             call.cancel();
         }
-        if (reader != null) {
-            reader.close();
+        if (sseReader != null) {
+            sseReader.close();
         }
     }
 

--- a/src/main/java/com/here/oksse/RealServerSentEvent.java
+++ b/src/main/java/com/here/oksse/RealServerSentEvent.java
@@ -95,6 +95,7 @@ class RealServerSentEvent implements ServerSentEvent {
             listener.onClosed(this);
             if (call != null && !call.isCanceled()) {
                 call.cancel();
+                close();
             }
         }
     }

--- a/src/main/java/com/here/oksse/RealServerSentEvent.java
+++ b/src/main/java/com/here/oksse/RealServerSentEvent.java
@@ -31,6 +31,7 @@ class RealServerSentEvent implements ServerSentEvent {
     private OkHttpClient client;
     private Call call;
     private Reader sseReader;
+    private ResponseBody responseBody;
 
     private long reconnectTime = TimeUnit.SECONDS.toMillis(3);
     private long readTimeoutMillis = 0;
@@ -81,7 +82,8 @@ class RealServerSentEvent implements ServerSentEvent {
     }
 
     private void openSse(Response response) {
-        sseReader = new Reader(response.body().source());
+        responseBody = response.body();
+        sseReader = new Reader(responseBody.source());
         sseReader.setTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS);
         listener.onOpen(this, response);
 
@@ -136,6 +138,9 @@ class RealServerSentEvent implements ServerSentEvent {
     public void close() {
         if (call != null) {
             call.cancel();
+        }
+        if (responseBody != null) {
+            responseBody.close();
         }
     }
 


### PR DESCRIPTION
This fixes the warning below:
```
Feb 19, 2018 7:16:00 PM okhttp3.internal.platform.Platform log
WARNING: A connection to https://example.com/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```