### PR TITLE
Fix retry mechanism and properly unregister listener with closing

### DIFF
--- a/src/main/java/com/here/oksse/RealServerSentEvent.java
+++ b/src/main/java/com/here/oksse/RealServerSentEvent.java
@@ -107,6 +107,7 @@ class RealServerSentEvent implements ServerSentEvent {
             }
             if (call != null && !call.isCanceled()) {
                 call.cancel();
+                close();
             }
         }
     }
@@ -160,6 +161,9 @@ class RealServerSentEvent implements ServerSentEvent {
     public void close() {
         if (call != null) {
             call.cancel();
+        }
+        if (sseReader != null) {
+            sseReader.close();
         }
         synchronized (this) {
             listener = null;


### PR DESCRIPTION
Fix retry mechanism, properly unregister listener with closing  …
* fix retry - add required Last-Event-Id header
* listener - null out listener at close() to prevent holding reference,
  make sure listener callbacks will not be called after calling close() method