### PR TITLE
Added try-with-resources clause to response body handling

### DIFF
--- a/src/main/java/com/here/oksse/RealServerSentEvent.java
+++ b/src/main/java/com/here/oksse/RealServerSentEvent.java
@@ -85,12 +85,14 @@ class RealServerSentEvent implements ServerSentEvent {
     }
 
     private void openSse(Response response) {
-        sseReader = new Reader(response.body().source());
-        sseReader.setTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS);
-        listener.onOpen(this, response);
+        try (ResponseBody body = response.body()) {
+            sseReader = new Reader(body.source());
+            sseReader.setTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS);
+            listener.onOpen(this, response);
 
-        //noinspection StatementWithEmptyBody
-        while (call != null && !call.isCanceled() && sseReader.read()) {
+            //noinspection StatementWithEmptyBody
+            while (call != null && !call.isCanceled() && sseReader.read()) {
+            }
         }
     }
 


### PR DESCRIPTION
Prevent warning about leaked connection (' A connection to https://xyz.com/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.
getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);').