### PR TITLE
Allow HTTP/2 connections

### DIFF
--- a/src/main/java/com/here/oksse/OkSse.java
+++ b/src/main/java/com/here/oksse/OkSse.java
@@ -65,7 +65,7 @@ public class OkSse {
      * @param client
      */
     public OkSse(OkHttpClient client) {
-        this.client = client.newBuilder().protocols(Collections.singletonList(Protocol.HTTP_1_1)).build();
+        this.client = client;
     }
 
     /**


### PR DESCRIPTION
- When supplying a custom OkHttpClient, don't enforce HTTP/1.1. We should keep the same
defaults as when using the default constructor. This was causing intermittent issues
with certain streams, causing them to get stuck half-way through.

I'm curious as to why HTTP 1 was explicitly forced like this?  Were you seeing issues? 